### PR TITLE
latest cf cli v6

### DIFF
--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -7,7 +7,7 @@ steps:
   artifactPrepareVersion:
     versioningType: 'cloud_noTag'
   cloudFoundryDeploy:
-    dockerImage: 'ppiper/cf-cli:v2'
+    dockerImage: 'ppiper/cf-cli:6'
     useGoStep: true
     apiEndpoint: 'https://api.cf.eu10.hana.ondemand.com'
     deployTool: cf_native


### PR DESCRIPTION
Version `6` contains the latest (... well one of the latest :-)) version `6` of cf-cli (which means `6.xx.yyy).

This is what we use also in the piper lib. Since the test should be close to reality it makes sense to use that `6` version of `ppiper/cf-cli`. 